### PR TITLE
Auth app faz requisição para graphql_api e recebe as policies

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,12 +19,15 @@ class HomeController < ApplicationController
 
     begin
       response = Net::HTTP.post(uri, body.to_json, headers)
-      @policies = JSON.parse(response.body)
+      if response.code == "200"
+        @policies = JSON.parse(response.body)
+        @request_completed = true
+      else
+        raise "#{response.message}"
+      end
     rescue StandardError => error
-      @error_message = "Ocorreu um erro e não foi possível fazer a consulta das apólices. Erro: #{error}"
-      Rails.logger.warn(@message)
-    else
-      @request_completed = true
+      @error_message = "Ocorreu um erro e não foi possível fazer a consulta das apólices. Erro: #{error.message}"
+      Rails.logger.warn(@error_message)
     end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,23 @@
+require 'net/http'
 class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    # Listar Policies
+    uri = URI('http://graphql_api:3001/graphql')
+    body = {
+      query: "query {
+        policies {
+          dataEmissao
+          segurado {
+            nome
+            cpf
+          }
+        }
+      }"
+    }
+    headers = { 'Content-Type' => 'application/json' }
+
+    response = Net::HTTP.post(uri, body.to_json, headers)
+    @policies = JSON.parse(response.body)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,7 +17,14 @@ class HomeController < ApplicationController
     }
     headers = { 'Content-Type' => 'application/json' }
 
-    response = Net::HTTP.post(uri, body.to_json, headers)
-    @policies = JSON.parse(response.body)
+    begin
+      response = Net::HTTP.post(uri, body.to_json, headers)
+      @policies = JSON.parse(response.body)
+    rescue StandardError => error
+      @message = "Ocorreu um erro e não foi possível fazer a consulta das apólices. Erro: #{error}"
+      Rails.logger.warn(@message)
+    else
+      @request_completed = true
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,7 +21,7 @@ class HomeController < ApplicationController
       response = Net::HTTP.post(uri, body.to_json, headers)
       @policies = JSON.parse(response.body)
     rescue StandardError => error
-      @message = "Ocorreu um erro e não foi possível fazer a consulta das apólices. Erro: #{error}"
+      @error_message = "Ocorreu um erro e não foi possível fazer a consulta das apólices. Erro: #{error}"
       Rails.logger.warn(@message)
     else
       @request_completed = true

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,10 @@
 <h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
   <h4> Parabéns <%= current_user.email %> </h4>
-  <% if @request_completed %>
-    <p><%= @policies %></p>
+  <%= @error_message unless @request_completed %>
+  <% if @policies["data"]["policies"].empty? %>
+    <p> No momento não há nenhuma apólice cadastrada </p>
   <% else %>
-    <p><%= @message %></p>
+    <%= @policies %>
   <% end %>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,5 @@
 <h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
   <h4> Parabéns <%=current_user.email%> </h4>
+  <p><%= @policies %>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,9 @@
 <h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
-  <h4> Parabéns <%=current_user.email%> </h4>
-  <p><%= @policies %>
+  <h4> Parabéns <%= current_user.email %> </h4>
+  <% if @request_completed %>
+    <p><%= @policies %></p>
+  <% else %>
+    <p><%= @message %></p>
+  <% end %>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,10 +1,13 @@
 <h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
   <h4> Parabéns <%= current_user.email %> </h4>
-  <%= @error_message unless @request_completed %>
-  <% if @policies["data"]["policies"].empty? %>
-    <p> No momento não há nenhuma apólice cadastrada </p>
+  <% if @request_completed %>
+    <% if @policies["data"]["policies"].present? %>
+      <%= @policies %>
+    <% else %>
+      <p> No momento não há nenhuma apólice cadastrada </p>
+    <% end %>
   <% else %>
-    <%= @policies %>
+    <%= @error_message %>
   <% end %>
 <% end %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,15 @@ services:
     stdin_open: true
     volumes:
       - .:/auth_app/
+      - rubygems:/usr/local/bundle
+
     ports:
       - "3007:3007"
     networks:
     - policy-network
+
+volumes:
+  rubygems:
 
 networks:
   policy-network:


### PR DESCRIPTION
### Descrição:

Após criação do Auth app (nosso app web), instalação do devise e configuração do compose, é necessário fazer nosso app bater na Api GraphQL, com uma query graphql, que retornará as policies para que a gente possa listar no nosso app após o usuário logar.

#### O que foi feito:
Neste PR foi feito a primeira etapa. Fazer uma requisição na Api GraphQL, e retornar as policies.