### PR TITLE
List Policies After Login

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
     body = {
       query: "query {
         policies {
+          policyId
           dataEmissao
           segurado {
             nome
@@ -18,6 +19,8 @@ class HomeController < ApplicationController
     headers = { 'Content-Type' => 'application/json' }
 
     response = Net::HTTP.post(uri, body.to_json, headers)
-    @policies = JSON.parse(response.body)
+    policies_hash = JSON.parse(response.body)
+
+    @policies = policies_hash["data"]["policies"]
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,23 @@
+require 'net/http'
 class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    # Listar Policies
+    uri = URI('http://graphql_api:3001/graphql')
+    body = {
+      query: "query {
+        policies {
+          dataEmissao
+          segurado {
+            nome
+            cpf
+          }
+        }
+      }"
+    }
+    headers = { 'Content-Type' => 'application/json' }
+
+    response = Net::HTTP.post(uri, body.to_json, headers)
+    @policies = JSON.parse(response.body)
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,21 @@
-<h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
-  <h4> Parabéns <%=current_user.email%> </h4>
-  <p><%= @policies %>
+  <h2> Bem vindo <%=current_user.email%>! </h2>
+  <br><br>
+  <h1> Lista de Apólices cadastradas </h1>
+  <table>
+    <tr>
+      <th>Id</th>
+      <th>Data de Emissão</th>
+      <th>Nome do Segurado</th>
+      <th>CPF do Segurado</th>
+    </tr>
+  <% @policies.each do |policy| %>
+    <tr>
+      <td> <%= policy["policyId"] %> </td>
+      <td> <%= policy["dataEmissao"] || "Não Registrado" %> </td>
+      <td> <%= policy["segurado"]["nome"] %> </td>
+      <td> <%= policy["segurado"]["cpf"] %> </td>
+    </tr>
+  <% end %>
+  </table>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,5 @@
 <h1> Listar as views aqui </h1>
 <% if user_signed_in? %>
   <h4> Parabéns <%=current_user.email%> </h4>
+  <p><%= @policies %>
 <% end %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,15 @@ services:
     stdin_open: true
     volumes:
       - .:/auth_app/
+      - rubygems:/usr/local/bundle
+
     ports:
       - "3007:3007"
     networks:
     - policy-network
+
+volumes:
+  rubygems:
 
 networks:
   policy-network:


### PR DESCRIPTION
## Descrição:

Após o login, queremos que a página inicial liste as apólices que já estão cadastradas.
No PR [Auth app faz requisição para graphql_api e recebe as policies
](https://github.com/FernandoInkaPuri/auth_app_experiment/pull/1) foi feito a primeira etapa, de bater na api graphql que por sua vez busca as policies cadastradas e nos retorna. 

Neste PR faremos a segunda parte, que é listar essas apólices na página inicial.

## O que foi feito:

Na página inicial foi criado uma tabela para listar as apólices e seus campos Id, Data de Emissão, Nome do Segurado e CPF do Segurado.

 